### PR TITLE
Add feature exclude app from recents & fix a bug from code editor

### DIFF
--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/activity/MainActivity.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/activity/MainActivity.kt
@@ -2,6 +2,7 @@ package me.timschneeberger.rootlessjamesdsp.activity
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.ActivityManager
 import android.content.*
 import android.content.pm.PackageManager
 import android.media.projection.MediaProjectionManager
@@ -13,6 +14,7 @@ import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.core.content.getSystemService
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.preference.DialogPreference.TargetFragment
@@ -76,6 +78,9 @@ class MainActivity : BaseActivity() {
 
     /* General */
     private val prefsVar by lazy { getSharedPreferences(Constants.PREF_VAR, Context.MODE_PRIVATE) }
+
+    /* App */
+    private val prefsApp by lazy { getSharedPreferences(Constants.PREF_APP, Context.MODE_PRIVATE) }
 
     private var processorService: BaseAudioProcessorService? = null
     private var processorServiceBound: Boolean = false
@@ -419,6 +424,14 @@ class MainActivity : BaseActivity() {
 
         if(BuildConfig.ROOTLESS)
             binding.powerToggle.isToggled = processorService != null
+
+        excludeAppFromRecents()
+    }
+
+    private fun excludeAppFromRecents() {
+        getSystemService<ActivityManager>()?.appTasks?.takeIf { it.isNotEmpty() }?.forEach {
+            it.setExcludeFromRecents(prefsApp.getBoolean(getString(R.string.key_exclude_app_from_recents), false))
+        }
     }
 
     private fun showLibraryLoadError() {

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/editor/plugin/SourcePositionListener.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/editor/plugin/SourcePositionListener.kt
@@ -20,8 +20,8 @@ class SourcePositionListener(private val editText: EditText) {
                 super.sendAccessibilityEvent(host, eventType)
                 if (eventType == AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED && onPositionChanged != null) {
                     val selectionStart = editText.selectionStart
-                    val line = editText.layout.getLineForOffset(selectionStart)
-                    val column = selectionStart - editText.layout.getLineStart(line)
+                    val line = editText.layout?.getLineForOffset(selectionStart) ?: 0
+                    val column = selectionStart - (editText.layout?.getLineStart(line) ?: 0)
                     onPositionChanged?.onPositionChange(line + 1, column + 1)
                 }
             }

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -30,6 +30,7 @@
     <string name="key_session_continuous_polling" translatable="false">session_continuous_polling</string>
     <string name="key_session_loss_ignore" translatable="false">session_loss_ignore</string>
     <string name="key_session_app_problem_ignore" translatable="false">session_app_problem_ignore</string>
+    <string name="key_exclude_app_from_recents" translatable="false">exclude_app_from_recents</string>
     <string name="key_autostart_prompt_at_boot" translatable="false">autostart_prompt_at_boot</string>
     <string name="key_powersave_suspend" translatable="false">powersave_suspend</string>
     <string name="key_audioformat_encoding" translatable="false">audioformat_encoding</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,10 @@
     <string name="audio_format_buffer_size">Buffer size</string>
     <string name="audio_format_buffer_size_unit">&#xa0;samples</string>
     <string name="audio_format_buffer_size_warning_low_value">Warning: Low buffer sizes may cause audio issues such as clipping!</string>
+    <string name="app_behavior">App Behavior</string>
+    <string name="exclude_app_from_recents">Exclude app from recents</string>
+    <string name="exclude_app_from_recents_off">Don\'t exclude app from recent tasks list</string>
+    <string name="exclude_app_from_recents_on">Exclude app from recent tasks list</string>
     <string name="autostart_prompt_at_boot">Prompt for capture permission after boot</string>
     <string name="autostart_prompt_at_boot_off">Don\'t show notification after boot</string>
     <string name="autostart_prompt_at_boot_on">Show notification after boot</string>

--- a/app/src/main/res/xml/app_misc_preferences.xml
+++ b/app/src/main/res/xml/app_misc_preferences.xml
@@ -1,5 +1,16 @@
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory app:title="@string/app_behavior"
+        app:iconSpaceReserved="false">
+        <me.timschneeberger.rootlessjamesdsp.preference.MaterialSwitchPreference
+            app:key="@string/key_exclude_app_from_recents"
+            app:title="@string/exclude_app_from_recents"
+            app:defaultValue="false"
+            app:summaryOff="@string/exclude_app_from_recents_off"
+            app:summaryOn="@string/exclude_app_from_recents_on"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="@string/autostart"
         app:iconSpaceReserved="false">
         <me.timschneeberger.rootlessjamesdsp.preference.MaterialSwitchPreference


### PR DESCRIPTION
Add a feature
- exclude app from recent tasks list cause some customize rom when clear the background task card then the app will be quickly killed
Fix a bug
- Null pointer exception when the EditText try to using getLayout function, test from the code editor and the last preset liveprog script

Hope you can review and adopt : )