### PR TITLE
Add Parametric EQ

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -166,6 +166,16 @@
         </activity>
 
         <activity
+            android:name=".activity.ParametricEqualizerActivity"
+            android:exported="false"
+            android:label="@string/title_activity_peq"
+            android:theme="@style/Theme.RootlessJamesDSP">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.MainActivity" />
+        </activity>
+
+        <activity
             android:name=".activity.GraphicEqualizerActivity"
             android:exported="false"
             android:label="@string/title_activity_geq"

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/activity/ParametricEqualizerActivity.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/activity/ParametricEqualizerActivity.kt
@@ -1,0 +1,25 @@
+package me.timschneeberger.rootlessjamesdsp.activity
+
+import android.os.Bundle
+import me.timschneeberger.rootlessjamesdsp.R
+import me.timschneeberger.rootlessjamesdsp.databinding.ActivityParametricEqBinding
+import me.timschneeberger.rootlessjamesdsp.fragment.ParametricEqualizerFragment
+
+class ParametricEqualizerActivity : BaseActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val binding = ActivityParametricEqBinding.inflate(layoutInflater)
+
+        setContentView(binding.root)
+        setSupportActionBar(binding.toolbar)
+
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.params, ParametricEqualizerFragment.newInstance())
+                .commit()
+        }
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.toolbar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
+    }
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/adapter/ParametricEqBandAdapter.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/adapter/ParametricEqBandAdapter.kt
@@ -1,0 +1,138 @@
+package me.timschneeberger.rootlessjamesdsp.adapter
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.databinding.ObservableArrayList
+import androidx.databinding.ObservableList
+import androidx.recyclerview.widget.RecyclerView
+import me.timschneeberger.rootlessjamesdsp.R
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqBand
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqBandList
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.*
+
+class ParametricEqBandAdapter(var bands: ParametricEqBandList) :
+    RecyclerView.Adapter<ParametricEqBandAdapter.ViewHolder>() {
+
+    private val dfFreq = DecimalFormat("0", DecimalFormatSymbols.getInstance())
+    private val dfGain = DecimalFormat("0", DecimalFormatSymbols.getInstance())
+    private val dfQ = DecimalFormat("0", DecimalFormatSymbols.getInstance())
+
+    init {
+        dfFreq.maximumFractionDigits = 1
+        dfGain.maximumFractionDigits = 2
+        dfQ.maximumFractionDigits = 2
+    }
+
+    var onItemsChanged: ((ParametricEqBandAdapter) -> Unit)? = null
+    var onItemClicked: ((ParametricEqBand, Int) -> Unit)? = null
+
+    private val callback = object : ObservableList.OnListChangedCallback<ObservableArrayList<ParametricEqBand>>() {
+        @SuppressLint("NotifyDataSetChanged")
+        override fun onChanged(sender: ObservableArrayList<ParametricEqBand>?) {
+            this@ParametricEqBandAdapter.notifyDataSetChanged()
+            onItemsChanged()
+        }
+
+        override fun onItemRangeChanged(
+            sender: ObservableArrayList<ParametricEqBand>?,
+            positionStart: Int,
+            itemCount: Int,
+        ) {
+            this@ParametricEqBandAdapter.notifyItemRangeChanged(positionStart, itemCount)
+            onItemsChanged()
+        }
+
+        override fun onItemRangeInserted(
+            sender: ObservableArrayList<ParametricEqBand>?,
+            positionStart: Int,
+            itemCount: Int,
+        ) {
+            this@ParametricEqBandAdapter.notifyItemRangeInserted(positionStart, itemCount)
+            onItemsChanged()
+        }
+
+        @SuppressLint("NotifyDataSetChanged")
+        override fun onItemRangeMoved(
+            sender: ObservableArrayList<ParametricEqBand>?,
+            fromPosition: Int,
+            toPosition: Int,
+            itemCount: Int,
+        ) {
+            this@ParametricEqBandAdapter.notifyDataSetChanged()
+            onItemsChanged()
+        }
+
+        override fun onItemRangeRemoved(
+            sender: ObservableArrayList<ParametricEqBand>?,
+            positionStart: Int,
+            itemCount: Int,
+        ) {
+            this@ParametricEqBandAdapter.notifyItemRangeRemoved(positionStart, itemCount)
+            onItemsChanged()
+        }
+    }
+
+    private fun onItemsChanged() {
+        this.onItemsChanged?.invoke(this)
+    }
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val filterType: TextView = view.findViewById(R.id.filter_type)
+        val freq: TextView = view.findViewById(R.id.freq)
+        val gain: TextView = view.findViewById(R.id.gain)
+        val qFactor: TextView = view.findViewById(R.id.q_factor)
+        val deleteButton: Button = view.findViewById(R.id.delete)
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        bands.addOnListChangedCallback(callback)
+        super.onAttachedToRecyclerView(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        bands.removeOnListChangedCallback(callback)
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
+    override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(viewGroup.context)
+            .inflate(R.layout.item_peq_band_list, viewGroup, false)
+        return ViewHolder(view)
+    }
+
+    @SuppressLint("SetTextI18n")
+    override fun onBindViewHolder(viewHolder: ViewHolder, position: Int) {
+        viewHolder.deleteButton.isEnabled = true
+
+        val band = bands[position]
+        viewHolder.filterType.text = band.filterType.displayLabel
+        viewHolder.freq.text = "${dfFreq.format(band.frequency)}Hz"
+        viewHolder.gain.text = "${dfGain.format(band.gain)}dB"
+        viewHolder.qFactor.text = "Q${dfQ.format(band.q)}"
+
+        viewHolder.deleteButton.setOnClickListener {
+            viewHolder.bindingAdapterPosition.let { pos ->
+                if (pos >= 0) {
+                    bands.removeAt(pos)
+                }
+            }
+            viewHolder.deleteButton.isEnabled = false
+        }
+
+        viewHolder.itemView.setOnClickListener {
+            viewHolder.bindingAdapterPosition.let { pos ->
+                bands.getOrNull(pos)?.let {
+                    onItemClicked?.invoke(it, pos)
+                }
+            }
+        }
+    }
+
+    override fun getItemCount() = bands.size
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/DspFragment.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/DspFragment.kt
@@ -89,6 +89,10 @@ class DspFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeListen
                     R.xml.dsp_equalizer_preferences
                 ))
             .replace(
+                R.id.card_peq, PreferenceGroupFragment.newInstance(Constants.PREF_PEQ,
+                    R.xml.dsp_parametriceq_preferences
+                ))
+            .replace(
                 R.id.card_geq, PreferenceGroupFragment.newInstance(Constants.PREF_GEQ,
                     R.xml.dsp_graphiceq_preferences
                 ))

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/ParametricEqualizerFragment.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/ParametricEqualizerFragment.kt
@@ -1,0 +1,430 @@
+package me.timschneeberger.rootlessjamesdsp.fragment
+
+import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.res.Configuration
+import android.content.res.Configuration.ORIENTATION_LANDSCAPE
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import me.timschneeberger.rootlessjamesdsp.R
+import me.timschneeberger.rootlessjamesdsp.activity.ParametricEqualizerActivity
+import me.timschneeberger.rootlessjamesdsp.adapter.ParametricEqBandAdapter
+import me.timschneeberger.rootlessjamesdsp.databinding.FragmentParametricEqBinding
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqBand
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqBandList
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqFilterType
+import me.timschneeberger.rootlessjamesdsp.utils.Constants
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.registerLocalReceiver
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.sendLocalBroadcast
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.showInputAlert
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.showYesNoAlert
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.toast
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.unregisterLocalReceiver
+import timber.log.Timber
+import java.util.UUID
+
+class ParametricEqualizerFragment : Fragment() {
+    private lateinit var binding: FragmentParametricEqBinding
+
+    private val adapter: ParametricEqBandAdapter
+        get() = binding.bandList.adapter as ParametricEqBandAdapter
+
+    private var editorBandBackup: ParametricEqBand? = null
+    private var editorBandUuid: UUID? = null
+    private var editorActive = false
+        set(value) {
+            field = value
+            binding.add.isEnabled = !value
+            binding.reset.isEnabled = !value
+            binding.importFile.isEnabled = !value
+            binding.exportFile.isEnabled = !value
+            binding.editString.isEnabled = !value
+        }
+
+    private val importFileLauncher =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            uri ?: return@registerForActivityResult
+            try {
+                val text = requireContext().contentResolver.openInputStream(uri)
+                    ?.bufferedReader()?.use { it.readText() } ?: return@registerForActivityResult
+                val result = adapter.bands.fromApoString(text)
+
+                // Apply imported preamp
+                binding.preampInput.value = result.preampDb.toFloat()
+                binding.equalizerSurface.setPreampDb(result.preampDb)
+
+                save()
+                updateViewState()
+                val msg = getString(R.string.peq_import_success, adapter.bands.size)
+                if (result.skippedFilters > 0) {
+                    requireContext().toast("$msg (${result.skippedFilters} unsupported filters skipped)")
+                } else {
+                    requireContext().toast(msg)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to import PEQ file")
+                requireContext().toast(R.string.peq_import_error)
+            }
+        }
+
+    private val exportFileLauncher =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("text/plain")) { uri ->
+            uri ?: return@registerForActivityResult
+            try {
+                val apoString = adapter.bands.toApoString(binding.preampInput.value.toDouble())
+                requireContext().contentResolver.openOutputStream(uri)?.bufferedWriter()?.use {
+                    it.write(apoString)
+                }
+                requireContext().toast(R.string.peq_export_success)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to export PEQ file")
+                requireContext().toast("Export failed: ${e.message}")
+            }
+        }
+
+    private val broadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            when (intent?.action) {
+                Constants.ACTION_PRESET_LOADED -> {
+                    activity?.finish()
+                    startActivity(Intent(requireContext(), ParametricEqualizerActivity::class.java).apply {
+                        flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    })
+                }
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        requireContext().registerLocalReceiver(broadcastReceiver, IntentFilter(Constants.ACTION_PRESET_LOADED))
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onDestroy() {
+        requireContext().unregisterLocalReceiver(broadcastReceiver)
+        super.onDestroy()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = FragmentParametricEqBinding.inflate(layoutInflater, container, false)
+
+        binding.previewCard.setOnClickListener {
+            if (resources.configuration.orientation != ORIENTATION_LANDSCAPE) {
+                val newState = !binding.equalizerSurface.isVisible
+                collapsePreview(newState)
+            }
+        }
+
+        binding.reset.setOnClickListener {
+            requireContext().showYesNoAlert(
+                R.string.peq_reset_confirm_title,
+                R.string.peq_reset_confirm,
+            ) {
+                if (it) {
+                    adapter.bands.deserialize(Constants.DEFAULT_PEQ)
+                    binding.preampInput.value = 0f
+                    binding.equalizerSurface.setPreampDb(0.0)
+                    updateViewState()
+                    editorDiscard()
+                    save()
+                }
+            }
+        }
+
+        binding.editString.setOnClickListener {
+            requireContext().showInputAlert(
+                layoutInflater,
+                R.string.peq_edit_as_string,
+                R.string.peq_edit_hint,
+                adapter.bands.toApoString(binding.preampInput.value.toDouble()),
+                false,
+                null
+            ) {
+                it?.let { text ->
+                    val result = adapter.bands.fromApoString(text)
+                    // Apply parsed preamp
+                    binding.preampInput.value = result.preampDb.toFloat()
+                    binding.equalizerSurface.setPreampDb(result.preampDb)
+                }
+                save()
+            }
+        }
+
+        binding.add.setOnClickListener {
+            if (editorActive) return@setOnClickListener
+
+            editorBandBackup = null
+            editorBandUuid = null
+            editorActive = true
+
+            binding.freqInput.value = 1000f
+            binding.gainInput.value = 0f
+            binding.qInput.value = 1.41f
+            setFilterTypeSelection(ParametricEqFilterType.PEAKING)
+            updateViewState()
+        }
+
+        binding.importFile.setOnClickListener {
+            importFileLauncher.launch(arrayOf("text/plain", "text/*"))
+        }
+
+        binding.exportFile.setOnClickListener {
+            exportFileLauncher.launch("parametric_eq.txt")
+        }
+
+        binding.freqInput.setOnValueChangedListener { editorApply() }
+        binding.gainInput.setOnValueChangedListener { editorApply() }
+        binding.qInput.setOnValueChangedListener { editorApply() }
+
+        binding.filterTypeGroup.addOnButtonCheckedListener { _, _, isChecked ->
+            if (isChecked) editorApply()
+        }
+
+        binding.freqInput.customStepScale = { value: Float, _: Boolean ->
+            when (value) {
+                in 0f..400f -> 10f
+                in 400f..600f -> 20f
+                in 600f..1000f -> 50f
+                in 1000f..5000f -> 100f
+                in 5000f..Float.MAX_VALUE -> 500f
+                else -> 10f
+            }
+        }
+
+        binding.qInput.customStepScale = { value: Float, _: Boolean ->
+            when (value) {
+                in 0f..1f -> 0.05f
+                in 1f..5f -> 0.1f
+                in 5f..10f -> 0.5f
+                in 10f..Float.MAX_VALUE -> 1f
+                else -> 0.1f
+            }
+        }
+
+        binding.confirm.setOnClickListener {
+            editorSave()
+        }
+
+        binding.cancel.setOnClickListener {
+            editorDiscard()
+        }
+
+        // Preamp listener
+        binding.preampInput.setOnValueChangedListener {
+            binding.equalizerSurface.setPreampDb(binding.preampInput.value.toDouble())
+            savePreamp()
+        }
+
+        // Load band data
+        binding.bandList.layoutManager = LinearLayoutManager(requireContext())
+        loadBands(savedInstanceState)
+
+        updateViewState()
+        return binding.root
+    }
+
+    private fun loadBands(savedInstanceState: Bundle?) {
+        val bands = ParametricEqBandList()
+        val prefs = requireContext().getSharedPreferences(Constants.PREF_PEQ, Context.MODE_PRIVATE)
+        val dataSaved = savedInstanceState?.getBundle(STATE_BANDS)
+        if (dataSaved != null) {
+            bands.fromBundle(dataSaved)
+        } else {
+            val bandString = prefs?.getString(getString(R.string.key_peq_bands), Constants.DEFAULT_PEQ)!!
+            bands.deserialize(bandString)
+        }
+
+        // Load preamp
+        val preampDb = prefs?.getFloat(getString(R.string.key_peq_preamp), 0f) ?: 0f
+        binding.preampInput.value = preampDb
+        binding.equalizerSurface.setBands(bands, preampDb.toDouble())
+
+        binding.bandList.adapter = ParametricEqBandAdapter(bands).apply {
+            onItemsChanged = {
+                binding.equalizerSurface.setBands(it.bands, binding.preampInput.value.toDouble())
+                updateViewState()
+                save()
+            }
+
+            onItemClicked = { band: ParametricEqBand, _: Int ->
+                editorBandBackup = band
+                editorBandUuid = band.uuid
+                editorActive = true
+
+                binding.freqInput.value = band.frequency.toFloat()
+                binding.gainInput.value = band.gain.toFloat()
+                binding.qInput.value = band.q.toFloat()
+                setFilterTypeSelection(band.filterType)
+                updateViewState()
+            }
+        }
+    }
+
+    private fun getSelectedFilterType(): ParametricEqFilterType {
+        return when (binding.filterTypeGroup.checkedButtonId) {
+            R.id.filter_low_shelf -> ParametricEqFilterType.LOW_SHELF
+            R.id.filter_high_shelf -> ParametricEqFilterType.HIGH_SHELF
+            else -> ParametricEqFilterType.PEAKING
+        }
+    }
+
+    private fun setFilterTypeSelection(type: ParametricEqFilterType) {
+        val buttonId = when (type) {
+            ParametricEqFilterType.PEAKING -> R.id.filter_peaking
+            ParametricEqFilterType.LOW_SHELF -> R.id.filter_low_shelf
+            ParametricEqFilterType.HIGH_SHELF -> R.id.filter_high_shelf
+        }
+        binding.filterTypeGroup.check(buttonId)
+    }
+
+    private fun updateViewState() {
+        val empty = adapter.bands.isEmpty()
+        binding.emptyView.isVisible = empty && !editorActive
+        binding.bandList.isVisible = !empty && !editorActive
+        binding.bandEdit.isVisible = editorActive
+        binding.bandDetailContextButtons.visibility = if (editorActive) View.VISIBLE else View.INVISIBLE
+        binding.editCardTitle.text = getString(if (editorActive) R.string.peq_band_editor else R.string.peq_band_list)
+    }
+
+    override fun onStop() {
+        if (editorActive) {
+            Timber.d("onStop: discarding unsaved changes")
+            editorDiscard()
+        }
+        super.onStop()
+    }
+
+    private fun editorCanSave(): Boolean {
+        val freqValid = binding.freqInput.isCurrentValueValid()
+        val gainValid = binding.gainInput.isCurrentValueValid()
+        val qValid = binding.qInput.isCurrentValueValid()
+        return freqValid && gainValid && qValid
+    }
+
+    private fun editorApply() {
+        if (editorCanSave()) {
+            val uuid = editorBandUuid
+            val freq = binding.freqInput.value.toDouble()
+            val gain = binding.gainInput.value.toDouble()
+            val q = binding.qInput.value.toDouble()
+            val filterType = getSelectedFilterType()
+
+            if (uuid == null) {
+                val band = ParametricEqBand(freq, gain, q, filterType)
+                adapter.bands.add(band)
+                editorBandUuid = band.uuid
+                Timber.d("editorApply: tracking new band $editorBandUuid for $freq Hz $gain dB Q$q $filterType")
+            } else {
+                Timber.d("editorApply: modifying band $editorBandUuid")
+                val index = adapter.bands.indexOfFirst { it.uuid == uuid }
+                if (index < 0)
+                    Timber.e("editorApply: failed to find matching band UUID")
+                else
+                    adapter.bands[index] = ParametricEqBand(freq, gain, q, filterType, uuid)
+            }
+        }
+    }
+
+    private fun editorDiscard() {
+        val uuid = editorBandUuid
+        if (editorBandBackup != null && uuid != null) {
+            Timber.d("editorDiscard: reverting modifications to band $uuid")
+            val index = adapter.bands.indexOfFirst { it.uuid == uuid }
+            if (index < 0)
+                Timber.e("editorDiscard: failed to find matching band UUID")
+            else
+                adapter.bands[index] = editorBandBackup
+        } else if (uuid != null) {
+            Timber.d("editorDiscard: reverting addition of band $uuid")
+            adapter.bands.removeAll { it.uuid == uuid }
+        }
+
+        editorBandBackup = null
+        editorBandUuid = null
+        editorActive = false
+        updateViewState()
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    private fun editorSave() {
+        if (!editorCanSave()) {
+            requireContext().showYesNoAlert(
+                R.string.peq_discard_changes_title,
+                R.string.peq_discard_changes
+            ) {
+                if (it) {
+                    editorDiscard()
+                }
+            }
+            return
+        }
+
+        Timber.d("editorSave: confirming changes to band $editorBandUuid")
+        editorBandBackup = null
+        editorBandUuid = null
+        editorActive = false
+
+        adapter.notifyDataSetChanged()
+        updateViewState()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        if (newConfig.orientation == ORIENTATION_LANDSCAPE) {
+            collapsePreview(false)
+        }
+        super.onConfigurationChanged(newConfig)
+    }
+
+    private fun collapsePreview(collapsed: Boolean) {
+        binding.equalizerSurface.isVisible = collapsed
+        binding.previewTitle.text =
+            getString(if (collapsed) R.string.peq_preview else R.string.peq_preview_collapsed)
+    }
+
+    @SuppressLint("ApplySharedPref")
+    private fun save() {
+        requireContext().getSharedPreferences(Constants.PREF_PEQ, Context.MODE_PRIVATE)
+            .edit()
+            .putString(getString(R.string.key_peq_bands), adapter.bands.serialize())
+            .putFloat(getString(R.string.key_peq_preamp), binding.preampInput.value)
+            .commit()
+        requireContext().sendLocalBroadcast(Intent(Constants.ACTION_PARAMETRIC_EQ_CHANGED))
+    }
+
+    @SuppressLint("ApplySharedPref")
+    private fun savePreamp() {
+        requireContext().getSharedPreferences(Constants.PREF_PEQ, Context.MODE_PRIVATE)
+            .edit()
+            .putFloat(getString(R.string.key_peq_preamp), binding.preampInput.value)
+            .commit()
+        requireContext().sendLocalBroadcast(Intent(Constants.ACTION_PARAMETRIC_EQ_CHANGED))
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        if (editorActive)
+            editorDiscard()
+
+        super.onSaveInstanceState(outState)
+    }
+
+    companion object {
+        const val STATE_BANDS = "bands"
+
+        fun newInstance(): ParametricEqualizerFragment {
+            return ParametricEqualizerFragment()
+        }
+    }
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/PreferenceGroupFragment.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/PreferenceGroupFragment.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView
 import me.timschneeberger.rootlessjamesdsp.R
 import me.timschneeberger.rootlessjamesdsp.activity.GraphicEqualizerActivity
 import me.timschneeberger.rootlessjamesdsp.activity.LiveprogEditorActivity
+import me.timschneeberger.rootlessjamesdsp.activity.ParametricEqualizerActivity
 import me.timschneeberger.rootlessjamesdsp.activity.LiveprogParamsActivity
 import me.timschneeberger.rootlessjamesdsp.adapter.RoundedRipplePreferenceGroupAdapter
 import me.timschneeberger.rootlessjamesdsp.liveprog.EelParser
@@ -180,6 +181,13 @@ class PreferenceGroupFragment : PreferenceFragmentCompat(), KoinComponent {
             R.xml.dsp_graphiceq_preferences -> {
                 findPreference<Preference>(getString(R.string.key_geq_nodes))?.setOnPreferenceClickListener {
                     val intent = Intent(requireContext(), GraphicEqualizerActivity::class.java)
+                    startActivity(intent)
+                    true
+                }
+            }
+            R.xml.dsp_parametriceq_preferences -> {
+                findPreference<Preference>(getString(R.string.key_peq_bands))?.setOnPreferenceClickListener {
+                    val intent = Intent(requireContext(), ParametricEqualizerActivity::class.java)
                     startActivity(intent)
                     true
                 }

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/model/ParametricEqBand.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/model/ParametricEqBand.kt
@@ -1,0 +1,55 @@
+package me.timschneeberger.rootlessjamesdsp.model
+
+import java.io.Serializable
+import java.util.*
+
+enum class ParametricEqFilterType(val code: Int, val apoLabel: String, val displayLabel: String) {
+    PEAKING(0, "PK", "PK"),
+    LOW_SHELF(1, "LSC", "LS"),
+    HIGH_SHELF(2, "HSC", "HS");
+
+    companion object {
+        fun fromCode(code: Int) = entries.firstOrNull { it.code == code } ?: PEAKING
+        fun fromApoLabel(label: String) = when (label.uppercase()) {
+            "PK" -> PEAKING
+            "LSC", "LS" -> LOW_SHELF
+            "HSC", "HS" -> HIGH_SHELF
+            else -> null
+        }
+    }
+}
+
+/**
+ * A parametric EQ band definition.
+ *
+ * [uuid] is excluded from equals/hashCode so that two bands with the
+ * same audio parameters compare as equal regardless of identity.
+ */
+class ParametricEqBand(
+    val frequency: Double,
+    val gain: Double,
+    val q: Double,
+    val filterType: ParametricEqFilterType = ParametricEqFilterType.PEAKING,
+    val uuid: UUID = UUID.randomUUID()
+) : Serializable {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ParametricEqBand) return false
+        return frequency == other.frequency &&
+                gain == other.gain &&
+                q == other.q &&
+                filterType == other.filterType
+    }
+
+    override fun hashCode(): Int {
+        var result = frequency.hashCode()
+        result = 31 * result + gain.hashCode()
+        result = 31 * result + q.hashCode()
+        result = 31 * result + filterType.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "ParametricEqBand(frequency=$frequency, gain=$gain, q=$q, filterType=$filterType, uuid=$uuid)"
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/model/ParametricEqBandList.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/model/ParametricEqBandList.kt
@@ -1,0 +1,204 @@
+package me.timschneeberger.rootlessjamesdsp.model
+
+import android.os.Bundle
+import androidx.databinding.ObservableArrayList
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.CompatExtensions.getSerializableAs
+import timber.log.Timber
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.*
+
+/**
+ * Result of parsing an EqualizerAPO format string.
+ * @param skippedFilters number of unsupported filter lines that were skipped
+ * @param preampDb the parsed Preamp value in dB (0.0 if not present)
+ */
+data class ApoImportResult(
+    val skippedFilters: Int,
+    val preampDb: Double
+)
+
+class ParametricEqBandList : ObservableArrayList<ParametricEqBand>() {
+    private val dfFreq = DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+    private val dfGain = DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+    private val dfQ = DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+
+    init {
+        dfFreq.maximumFractionDigits = 2
+        dfGain.maximumFractionDigits = 6
+        dfQ.maximumFractionDigits = 4
+    }
+
+    /**
+     * Internal serialization format for SharedPreferences.
+     * Format: "PEQ: freq gain q type; freq gain q type; ..."
+     */
+    fun serialize(): String {
+        val sb = StringBuilder("PEQ: ")
+        for (band in this) {
+            sb.append("${dfFreq.format(band.frequency)} ${dfGain.format(band.gain)} ${dfQ.format(band.q)} ${band.filterType.code}; ")
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Parse the internal serialization format.
+     */
+    fun deserialize(str: String) {
+        this.clear()
+
+        str.replace("PEQ:", "")
+            .replace("\n", " ")
+            .split(";")
+            .map { it.trim() }
+            .filter(String::isNotBlank)
+            .forEach { s ->
+                val parts = s.split(" ").filter(String::isNotBlank)
+                val freq = parts.getOrNull(0)?.toDoubleOrNull()
+                val gain = parts.getOrNull(1)?.toDoubleOrNull()
+                val q = parts.getOrNull(2)?.toDoubleOrNull()
+                val type = parts.getOrNull(3)?.toIntOrNull()
+
+                if (freq != null && gain != null && q != null && type != null) {
+                    this.add(ParametricEqBand(freq, gain, q, ParametricEqFilterType.fromCode(type)))
+                }
+            }
+    }
+
+    /**
+     * Export to EqualizerAPO format.
+     * Example:
+     *   Preamp: 0 dB
+     *   Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q 1.41
+     *   Filter 2: ON LSC Fc 100 Hz Gain 5.0 dB Q 0.71
+     */
+    fun toApoString(preampDb: Double = 0.0): String {
+        val sb = StringBuilder()
+        sb.appendLine("Preamp: ${dfGain.format(preampDb)} dB")
+        for ((i, band) in this.withIndex()) {
+            sb.appendLine(
+                "Filter ${i + 1}: ON ${band.filterType.apoLabel} Fc ${dfFreq.format(band.frequency)} Hz Gain ${dfGain.format(band.gain)} dB Q ${dfQ.format(band.q)}"
+            )
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Parse EqualizerAPO format.
+     * Supports lines like:
+     *   Preamp: -3 dB
+     *   Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q 1.41
+     *   Filter 2: ON LSC Fc 100 Hz Gain 5.0 dB Q 0.71
+     * Parses Preamp value and filter bands.
+     * Returns [ApoImportResult] with the parsed preamp and number of skipped filters.
+     */
+    fun fromApoString(text: String): ApoImportResult {
+        this.clear()
+        var skipped = 0
+        var preampDb = 0.0
+
+        val filterRegex = Regex(
+            """Filter\s+\d+:\s+ON\s+(\S+)\s+Fc\s+([\d.]+)\s+Hz\s+Gain\s+([-\d.]+)\s+dB\s+Q\s+([\d.]+)""",
+            RegexOption.IGNORE_CASE
+        )
+        val preampRegex = Regex(
+            """Preamp:\s*([-\d.]+)\s*dB""",
+            RegexOption.IGNORE_CASE
+        )
+
+        for (line in text.lines()) {
+            val trimmed = line.trim()
+            if (trimmed.isBlank() || trimmed.startsWith("#")) {
+                continue
+            }
+
+            // Parse preamp line
+            if (trimmed.startsWith("Preamp", ignoreCase = true)) {
+                val preampMatch = preampRegex.find(trimmed)
+                if (preampMatch != null) {
+                    preampDb = preampMatch.groupValues[1].toDoubleOrNull() ?: 0.0
+                    // Clamp to valid range
+                    preampDb = preampDb.coerceIn(-30.0, 0.0)
+                } else {
+                    Timber.d("fromApoString: could not parse preamp line: $trimmed")
+                }
+                continue
+            }
+
+            val match = filterRegex.find(trimmed)
+            if (match == null) {
+                Timber.d("fromApoString: skipping unrecognized line: $trimmed")
+                continue
+            }
+
+            val typeStr = match.groupValues[1]
+            val freq = match.groupValues[2].toDoubleOrNull() ?: continue
+            val gain = match.groupValues[3].toDoubleOrNull() ?: continue
+            val q = match.groupValues[4].toDoubleOrNull() ?: continue
+
+            val filterType = ParametricEqFilterType.fromApoLabel(typeStr)
+            if (filterType == null) {
+                Timber.d("fromApoString: unsupported filter type '$typeStr', skipping")
+                skipped++
+                continue
+            }
+
+            this.add(ParametricEqBand(freq, gain, q, filterType))
+        }
+
+        return ApoImportResult(skippedFilters = skipped, preampDb = preampDb)
+    }
+
+    fun fromBundle(bundle: Bundle) {
+        this.clear()
+
+        val freq = bundle.getDoubleArray(STATE_FREQ) ?: return
+        val gain = bundle.getDoubleArray(STATE_GAIN) ?: return
+        val q = bundle.getDoubleArray(STATE_Q) ?: return
+        val types = bundle.getIntArray(STATE_TYPE) ?: return
+        val uuids = bundle.getSerializableAs<Array<UUID>>(STATE_UUID)
+
+        val count = minOf(freq.size, gain.size, q.size, types.size)
+        for (i in 0 until count) {
+            this.add(
+                ParametricEqBand(
+                    freq[i], gain[i], q[i],
+                    ParametricEqFilterType.fromCode(types[i]),
+                    uuids?.getOrNull(i) ?: UUID.randomUUID()
+                )
+            )
+        }
+    }
+
+    fun toBundle(): Bundle {
+        val bundle = Bundle()
+        val freqArr = DoubleArray(this.size)
+        val gainArr = DoubleArray(this.size)
+        val qArr = DoubleArray(this.size)
+        val typeArr = IntArray(this.size)
+        val uuidArr = arrayListOf<UUID>()
+
+        for ((i, band) in this.withIndex()) {
+            freqArr[i] = band.frequency
+            gainArr[i] = band.gain
+            qArr[i] = band.q
+            typeArr[i] = band.filterType.code
+            uuidArr.add(band.uuid)
+        }
+
+        bundle.putDoubleArray(STATE_FREQ, freqArr)
+        bundle.putDoubleArray(STATE_GAIN, gainArr)
+        bundle.putDoubleArray(STATE_Q, qArr)
+        bundle.putIntArray(STATE_TYPE, typeArr)
+        bundle.putSerializable(STATE_UUID, uuidArr.toTypedArray())
+        return bundle
+    }
+
+    companion object {
+        private const val STATE_FREQ = "peq_freq"
+        private const val STATE_GAIN = "peq_gain"
+        private const val STATE_Q = "peq_q"
+        private const val STATE_TYPE = "peq_type"
+        private const val STATE_UUID = "peq_uuid"
+    }
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/preference/ParametricEqualizerPreference.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/preference/ParametricEqualizerPreference.kt
@@ -1,0 +1,99 @@
+package me.timschneeberger.rootlessjamesdsp.preference
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.res.TypedArray
+import android.util.AttributeSet
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import me.timschneeberger.rootlessjamesdsp.R
+import me.timschneeberger.rootlessjamesdsp.databinding.PreferenceParametricEqualizerBinding
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqBandList
+import me.timschneeberger.rootlessjamesdsp.utils.Constants
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.registerLocalReceiver
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.unregisterLocalReceiver
+import timber.log.Timber
+import java.util.MissingFormatArgumentException
+
+class ParametricEqualizerPreference : Preference {
+
+    private var binding: PreferenceParametricEqualizerBinding? = null
+    private var initialValue: String = ""
+
+    private val broadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            updateFromPreferences()
+        }
+    }
+
+    constructor(
+        context: Context, attrs: AttributeSet?,
+        defStyleAttr: Int
+    ) : this(context, attrs, defStyleAttr, 0)
+
+    constructor(
+        context: Context, attrs: AttributeSet?
+    ) : this(context, attrs, androidx.preference.R.attr.preferenceStyle)
+
+    constructor(
+        context: Context
+    ) : this(context, null)
+
+    constructor(
+        context: Context, attrs: AttributeSet?, defStyleAttr: Int,
+        defStyleRes: Int
+    ) : super(context, attrs, defStyleAttr, defStyleRes) {
+        layoutResource = R.layout.preference_parametric_equalizer
+    }
+
+    override fun onAttached() {
+        context.registerLocalReceiver(broadcastReceiver, IntentFilter(Constants.ACTION_PARAMETRIC_EQ_CHANGED))
+        super.onAttached()
+    }
+
+    override fun onDetached() {
+        context.unregisterLocalReceiver(broadcastReceiver)
+        super.onDetached()
+    }
+
+    override fun onSetInitialValue(defaultValue: Any?) {
+        initialValue = getPersistedString(defaultValue as? String ?: "")
+    }
+
+    override fun onGetDefaultValue(a: TypedArray, index: Int): Any {
+        return a.getString(index).toString()
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        binding = PreferenceParametricEqualizerBinding.bind(holder.itemView)
+        setEqualizerViewValues(initialValue)
+    }
+
+    fun updateFromPreferences() {
+        initialValue = getPersistedString(initialValue)
+        setEqualizerViewValues(initialValue)
+    }
+
+    private fun setEqualizerViewValues(value: String) {
+        val bands = ParametricEqBandList()
+        bands.deserialize(value)
+
+        // Read preamp from SharedPreferences so the main screen preview reflects it
+        val preampDb = context.getSharedPreferences(Constants.PREF_PEQ, Context.MODE_PRIVATE)
+            .getFloat(context.getString(R.string.key_peq_preamp), 0f)
+            .toDouble()
+
+        binding?.layoutEqualizer?.setBands(bands, preampDb)
+        try {
+            binding?.bandCount?.text =
+                context.resources.getQuantityString(R.plurals.peq_bands_count, bands.size, bands.size)
+        } catch (ex: MissingFormatArgumentException) {
+            Timber.e(ex)
+            binding?.bandCount?.text = context.getString(R.string.peq_bands)
+        }
+    }
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/BiquadUtils.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/BiquadUtils.kt
@@ -1,0 +1,182 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqBand
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqFilterType
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.*
+import kotlin.math.*
+
+/**
+ * Biquad filter coefficient computation based on the
+ * Robert Bristow-Johnson Audio EQ Cookbook.
+ *
+ * All filters are second-order IIR (biquad) and inherently minimum phase.
+ */
+object BiquadUtils {
+
+    data class BiquadCoefficients(
+        val b0: Double, val b1: Double, val b2: Double,
+        val a0: Double, val a1: Double, val a2: Double
+    )
+
+    /**
+     * Compute biquad coefficients for a parametric EQ band.
+     *
+     * @param frequency Center/corner frequency in Hz
+     * @param gain Gain in dB
+     * @param q Q factor
+     * @param filterType PEAKING, LOW_SHELF, or HIGH_SHELF
+     * @param sampleRate Sample rate in Hz
+     * @return Biquad coefficients (b0, b1, b2, a0, a1, a2)
+     */
+    fun computeCoefficients(
+        frequency: Double,
+        gain: Double,
+        q: Double,
+        filterType: ParametricEqFilterType,
+        sampleRate: Double = 48000.0
+    ): BiquadCoefficients {
+        val A = 10.0.pow(gain / 40.0) // sqrt of linear gain
+        val omega = 2.0 * PI * frequency / sampleRate
+        val sinOmega = sin(omega)
+        val cosOmega = cos(omega)
+
+        return when (filterType) {
+            ParametricEqFilterType.PEAKING -> {
+                val alpha = sinOmega / (2.0 * q)
+                BiquadCoefficients(
+                    b0 = 1.0 + alpha * A,
+                    b1 = -2.0 * cosOmega,
+                    b2 = 1.0 - alpha * A,
+                    a0 = 1.0 + alpha / A,
+                    a1 = -2.0 * cosOmega,
+                    a2 = 1.0 - alpha / A
+                )
+            }
+            ParametricEqFilterType.LOW_SHELF -> {
+                val alpha = sinOmega / (2.0 * q)
+                val sqrtA = sqrt(A)
+                val twoSqrtAAlpha = 2.0 * sqrtA * alpha
+                BiquadCoefficients(
+                    b0 = A * ((A + 1.0) - (A - 1.0) * cosOmega + twoSqrtAAlpha),
+                    b1 = 2.0 * A * ((A - 1.0) - (A + 1.0) * cosOmega),
+                    b2 = A * ((A + 1.0) - (A - 1.0) * cosOmega - twoSqrtAAlpha),
+                    a0 = (A + 1.0) + (A - 1.0) * cosOmega + twoSqrtAAlpha,
+                    a1 = -2.0 * ((A - 1.0) + (A + 1.0) * cosOmega),
+                    a2 = (A + 1.0) + (A - 1.0) * cosOmega - twoSqrtAAlpha
+                )
+            }
+            ParametricEqFilterType.HIGH_SHELF -> {
+                val alpha = sinOmega / (2.0 * q)
+                val sqrtA = sqrt(A)
+                val twoSqrtAAlpha = 2.0 * sqrtA * alpha
+                BiquadCoefficients(
+                    b0 = A * ((A + 1.0) + (A - 1.0) * cosOmega + twoSqrtAAlpha),
+                    b1 = -2.0 * A * ((A - 1.0) + (A + 1.0) * cosOmega),
+                    b2 = A * ((A + 1.0) + (A - 1.0) * cosOmega - twoSqrtAAlpha),
+                    a0 = (A + 1.0) - (A - 1.0) * cosOmega + twoSqrtAAlpha,
+                    a1 = 2.0 * ((A - 1.0) - (A + 1.0) * cosOmega),
+                    a2 = (A + 1.0) - (A - 1.0) * cosOmega - twoSqrtAAlpha
+                )
+            }
+        }
+    }
+
+    /**
+     * Compute the magnitude response |H(e^jw)| in dB at a given frequency.
+     *
+     * Evaluates H(z) = (b0 + b1*z^-1 + b2*z^-2) / (a0 + a1*z^-1 + a2*z^-2)
+     * at z = e^(j*2*pi*f/fs).
+     */
+    fun magnitudeResponse(
+        coeffs: BiquadCoefficients,
+        frequency: Double,
+        sampleRate: Double = 48000.0
+    ): Double {
+        val omega = 2.0 * PI * frequency / sampleRate
+        val cosW = cos(omega)
+        val cos2W = cos(2.0 * omega)
+        val sinW = sin(omega)
+        val sin2W = sin(2.0 * omega)
+
+        // Numerator: b0 + b1*e^(-jw) + b2*e^(-j2w)
+        val numReal = coeffs.b0 + coeffs.b1 * cosW + coeffs.b2 * cos2W
+        val numImag = -(coeffs.b1 * sinW + coeffs.b2 * sin2W)
+
+        // Denominator: a0 + a1*e^(-jw) + a2*e^(-j2w)
+        val denReal = coeffs.a0 + coeffs.a1 * cosW + coeffs.a2 * cos2W
+        val denImag = -(coeffs.a1 * sinW + coeffs.a2 * sin2W)
+
+        val numMagSq = numReal * numReal + numImag * numImag
+        val denMagSq = denReal * denReal + denImag * denImag
+
+        return if (denMagSq > 0.0) {
+            10.0 * log10(numMagSq / denMagSq)
+        } else {
+            0.0
+        }
+    }
+
+    /**
+     * Compute the combined magnitude response of multiple parametric EQ bands
+     * sampled at logarithmically-spaced frequency points.
+     *
+     * @param bands List of parametric EQ bands
+     * @param numPoints Number of sample points (default 512)
+     * @param minFreq Minimum frequency in Hz
+     * @param maxFreq Maximum frequency in Hz
+     * @param sampleRate Sample rate for coefficient computation
+     * @return List of (frequency, totalGainDb) pairs
+     */
+    fun computeCombinedResponse(
+        bands: List<ParametricEqBand>,
+        numPoints: Int = 512,
+        minFreq: Double = 20.0,
+        maxFreq: Double = 20000.0,
+        sampleRate: Double = 48000.0
+    ): List<Pair<Double, Double>> {
+        if (bands.isEmpty()) return emptyList()
+
+        val logMin = ln(minFreq)
+        val logMax = ln(maxFreq)
+        val result = ArrayList<Pair<Double, Double>>(numPoints)
+
+        // Precompute coefficients for all bands
+        val allCoeffs = bands.map { band ->
+            computeCoefficients(band.frequency, band.gain, band.q, band.filterType, sampleRate)
+        }
+
+        for (i in 0 until numPoints) {
+            val t = i.toDouble() / (numPoints - 1).toDouble()
+            val freq = exp(logMin + t * (logMax - logMin))
+            var totalGain = 0.0
+
+            for (coeffs in allCoeffs) {
+                totalGain += magnitudeResponse(coeffs, freq, sampleRate)
+            }
+
+            result.add(Pair(freq, totalGain))
+        }
+
+        return result
+    }
+
+    private val dfFreq = DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+    private val dfGain = DecimalFormat("0.000000", DecimalFormatSymbols.getInstance(Locale.ENGLISH))
+
+    /**
+     * Convert a sampled frequency response to GraphicEQ format string
+     * suitable for the native ArbitraryResponseEqualizer.
+     *
+     * @param response List of (frequency, gainDb) pairs
+     * @param preampOffset Additional gain offset in dB (e.g. negative preamp to prevent clipping)
+     */
+    fun toGraphicEqString(response: List<Pair<Double, Double>>, preampOffset: Double = 0.0): String {
+        val sb = StringBuilder("GraphicEQ: ")
+        for ((freq, gain) in response) {
+            sb.append("${dfFreq.format(freq)} ${dfGain.format(gain + preampOffset)}; ")
+        }
+        return sb.toString()
+    }
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/Constants.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/Constants.kt
@@ -15,6 +15,7 @@ object Constants {
     const val PREF_DDC = "dsp_ddc"
     const val PREF_EQ = "dsp_equalizer"
     const val PREF_GEQ = "dsp_graphiceq"
+    const val PREF_PEQ = "dsp_parametriceq"
     const val PREF_LIVEPROG = "dsp_liveprog"
     const val PREF_OUTPUT = "dsp_output_control"
     const val PREF_REVERB = "dsp_reverb"
@@ -25,6 +26,7 @@ object Constants {
     const val DEFAULT_CONVOLVER_ADVIMP = "-80;-100;0;0;0;0"
     const val DEFAULT_GEQ = "GraphicEQ: "
     const val DEFAULT_GEQ_INTERNAL = "GraphicEQ: 0.0 0.0;"
+    const val DEFAULT_PEQ = "PEQ: "
     const val DEFAULT_EQ = "25.0;40.0;63.0;100.0;160.0;250.0;400.0;630.0;1000.0;1600.0;2500.0;4000.0;6300.0;10000.0;16000.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0"
 
     // Intent actions
@@ -32,6 +34,7 @@ object Constants {
     const val ACTION_SAMPLE_RATE_UPDATED = BuildConfig.APPLICATION_ID + ".action.sample_rate.UPDATED"
     const val ACTION_PRESET_LOADED = BuildConfig.APPLICATION_ID + ".action.preset.LOADED"
     const val ACTION_GRAPHIC_EQ_CHANGED = BuildConfig.APPLICATION_ID + ".action.preferences.graphiceq.CHANGED"
+    const val ACTION_PARAMETRIC_EQ_CHANGED = BuildConfig.APPLICATION_ID + ".action.preferences.parametriceq.CHANGED"
     const val ACTION_SESSION_CHANGED = BuildConfig.APPLICATION_ID + ".action.session.CHANGED"
     const val ACTION_SERVICE_STARTED = BuildConfig.APPLICATION_ID + ".action.service.STARTED"
     const val ACTION_SERVICE_STOPPED = BuildConfig.APPLICATION_ID + ".action.service.STOPPED"

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/view/ParametricEqSurface.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/view/ParametricEqSurface.kt
@@ -1,0 +1,229 @@
+package me.timschneeberger.rootlessjamesdsp.view
+
+import android.content.Context
+import android.graphics.*
+import android.os.Bundle
+import android.os.Parcelable
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.View
+import androidx.core.content.withStyledAttributes
+import androidx.core.os.bundleOf
+import me.timschneeberger.rootlessjamesdsp.model.ParametricEqBandList
+import me.timschneeberger.rootlessjamesdsp.utils.BiquadUtils
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.CompatExtensions.getParcelableAs
+import me.timschneeberger.rootlessjamesdsp.utils.extensions.prettyNumberFormat
+import kotlin.math.*
+
+class ParametricEqSurface(context: Context?, attrs: AttributeSet?) : View(context, attrs) {
+
+    private var mGridLines = Paint()
+    private var mGridThickLines = Paint()
+    private var mControlBarText = Paint()
+    private var mFrequencyResponseBg = Paint()
+    private var mFrequencyResponseHighlight = Paint()
+
+    private var mHeight = 0.0f
+    private var mWidth = 0.0f
+
+    // Sampled frequency response curve
+    private var mCurveFreqs = DoubleArray(0)
+    private var mCurveGains = DoubleArray(0)
+    private var mPreampDb = 0.0
+
+    private val nPts = 256
+
+    init {
+        mGridLines.color = getColor(android.R.attr.colorControlHighlight)
+        mGridLines.style = Paint.Style.STROKE
+        mGridLines.strokeWidth = 4f
+
+        mGridThickLines.color = getColor(android.R.attr.colorControlHighlight)
+        mGridThickLines.style = Paint.Style.STROKE
+        mGridThickLines.strokeWidth = 8f
+
+        mControlBarText.textAlign = Paint.Align.CENTER
+        mControlBarText.textSize = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_SP,
+            11f, getContext().resources.displayMetrics
+        )
+        mControlBarText.color = getColor(android.R.attr.textColorPrimary)
+        mControlBarText.isAntiAlias = true
+
+        mFrequencyResponseBg.style = Paint.Style.FILL
+        mFrequencyResponseBg.alpha = 192
+
+        mFrequencyResponseHighlight.style = Paint.Style.STROKE
+        mFrequencyResponseHighlight.color = getColor(android.R.attr.colorAccent)
+        mFrequencyResponseHighlight.isAntiAlias = true
+        mFrequencyResponseHighlight.strokeWidth = 8f
+    }
+
+    private fun getColor(colorAttribute: Int): Int {
+        if (isInEditMode) return Color.BLACK
+        var color = 0
+        context.withStyledAttributes(TypedValue().data, intArrayOf(colorAttribute)) {
+            color = getColor(0, 0)
+        }
+        return color
+    }
+
+    override fun onSaveInstanceState() =
+        bundleOf(
+            "super" to super.onSaveInstanceState(),
+            STATE_FREQ to mCurveFreqs,
+            STATE_GAIN to mCurveGains,
+            STATE_PREAMP to mPreampDb
+        )
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        super.onRestoreInstanceState((state as Bundle).getParcelableAs("super"))
+        mCurveFreqs = state.getDoubleArray(STATE_FREQ) ?: DoubleArray(0)
+        mCurveGains = state.getDoubleArray(STATE_GAIN) ?: DoubleArray(0)
+        mPreampDb = state.getDouble(STATE_PREAMP, 0.0)
+        updateDbRange()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        setLayerType(LAYER_TYPE_HARDWARE, null)
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        mWidth = (right - left).toFloat()
+        mHeight = (bottom - top).toFloat()
+
+        val responseColors =
+            intArrayOf(getColor(android.R.attr.colorAccent), getColor(android.R.color.transparent))
+        val responsePositions = floatArrayOf(0.0f, 1f)
+        mFrequencyResponseBg.shader =
+            LinearGradient(0f, 0f, 0f, mHeight, responseColors, responsePositions, Shader.TileMode.CLAMP)
+    }
+
+    private val freqResponse = Path()
+    private val freqResponseBg = Path()
+
+    override fun onDraw(canvas: Canvas) {
+        freqResponse.rewind()
+        freqResponseBg.rewind()
+
+        val zeroY = projectY(0f) * mHeight
+
+        if (mCurveFreqs.isNotEmpty()) {
+            // Draw smooth biquad frequency response curve (offset by preamp)
+            val preamp = mPreampDb.toFloat()
+            freqResponse.moveTo(
+                projectX(mCurveFreqs[0]) * mWidth,
+                projectY(mCurveGains[0].toFloat() + preamp) * mHeight
+            )
+            for (i in 1 until mCurveFreqs.size) {
+                freqResponse.lineTo(
+                    projectX(mCurveFreqs[i]) * mWidth,
+                    projectY(mCurveGains[i].toFloat() + preamp) * mHeight
+                )
+            }
+        } else {
+            // Flat line at 0dB (or at preamp level)
+            val preampY = projectY(mPreampDb.toFloat()) * mHeight
+            freqResponse.moveTo(0f, preampY)
+            freqResponse.lineTo(mWidth, preampY)
+        }
+
+        // Frequency scale labels
+        for (scale in FreqScale) {
+            val x = projectX(scale) * mWidth
+            canvas.drawText(scale.prettyNumberFormat(), x, mHeight - 16, mControlBarText)
+        }
+
+        // Draw horizontal dB grid lines
+        var dB = minDb + 3
+        while (dB <= maxDb - 3) {
+            val y = projectY(dB.toFloat()) * mHeight
+            if (dB == 0)
+                canvas.drawLine(0f, y, mWidth, y, mGridThickLines)
+            else
+                canvas.drawLine(0f, y, mWidth, y, mGridLines)
+            dB += 3
+        }
+
+        // Fill under curve
+        with(freqResponseBg) {
+            addPath(freqResponse)
+            offset(0f, -4f)
+            if (mCurveFreqs.isNotEmpty()) {
+                lineTo(projectX(mCurveFreqs.last()) * mWidth, mHeight)
+                lineTo(projectX(mCurveFreqs.first()) * mWidth, mHeight)
+            } else {
+                lineTo(mWidth, mHeight)
+                lineTo(0f, mHeight)
+            }
+            close()
+        }
+        canvas.drawPath(freqResponseBg, mFrequencyResponseBg)
+        canvas.drawPath(freqResponse, mFrequencyResponseHighlight)
+    }
+
+    fun setBands(bands: ParametricEqBandList, preampDb: Double = mPreampDb) {
+        mPreampDb = preampDb
+        if (bands.isEmpty()) {
+            mCurveFreqs = DoubleArray(0)
+            mCurveGains = DoubleArray(0)
+        } else {
+            val response = BiquadUtils.computeCombinedResponse(
+                bands,
+                numPoints = nPts,
+                minFreq = MIN_FREQ,
+                maxFreq = MAX_FREQ
+            )
+            mCurveFreqs = DoubleArray(response.size) { response[it].first }
+            mCurveGains = DoubleArray(response.size) { response[it].second }
+        }
+
+        updateDbRange()
+        postInvalidate()
+    }
+
+    fun setPreampDb(preampDb: Double) {
+        mPreampDb = preampDb
+        updateDbRange()
+        postInvalidate()
+    }
+
+    private fun updateDbRange() {
+        val preamp = mPreampDb
+        val minGain = (mCurveGains.minOrNull() ?: 0.0) + preamp
+        val maxGain = (mCurveGains.maxOrNull() ?: 0.0) + preamp
+        minDb = floor(minOf(minGain, -15.0)).toInt()
+        maxDb = ceil(maxOf(maxGain, 15.0)).toInt()
+    }
+
+    private fun projectX(frequency: Double): Float {
+        val position = ln(frequency)
+        val minimumPosition = ln(MIN_FREQ)
+        val maximumPosition = ln(MAX_FREQ)
+        return ((position - minimumPosition) / (maximumPosition - minimumPosition)).toFloat()
+    }
+
+    private fun projectY(dB: Float): Float {
+        val pos = (dB - minDb) / (maxDb - minDb)
+        return 1.0f - pos
+    }
+
+    private var minDb = -15
+    private var maxDb = 15
+
+    companion object {
+        private const val STATE_FREQ = "peq_curve_freq"
+        private const val STATE_GAIN = "peq_curve_gain"
+        private const val STATE_PREAMP = "peq_curve_preamp"
+
+        private const val MIN_FREQ = 20.0
+        private const val MAX_FREQ = 20000.0
+
+        private val FreqScale = doubleArrayOf(
+            25.0, 40.0, 63.0, 100.0, 160.0, 250.0, 400.0, 630.0,
+            1000.0, 1600.0, 2500.0, 4000.0, 6300.0, 10000.0, 16000.0
+        )
+    }
+}

--- a/app/src/main/res/layout/activity_parametric_eq.xml
+++ b/app/src/main/res/layout/activity_parametric_eq.xml
@@ -1,0 +1,33 @@
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:fitsSystemWindows="true"
+    tools:context=".activity.ParametricEqualizerActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        app:liftOnScroll="false">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:titleCentered="true" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+            <FrameLayout
+                android:id="@+id/params"
+                android:name="androidx.navigation.fragment.NavHostFragment"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_dsp.xml
+++ b/app/src/main/res/layout/fragment_dsp.xml
@@ -108,6 +108,17 @@
             android:layout_marginHorizontal="1dp">
 
             <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/card_peq"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="1dp">
+
+            <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/card_geq"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/fragment_parametric_eq.xml
+++ b/app/src/main/res/layout/fragment_parametric_eq.xml
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:layout_marginTop="4dp"
+    android:animateLayoutChanges="true">
+
+    <HorizontalScrollView
+        android:id="@+id/horizontalScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbarDefaultDelayBeforeFade="0"
+        app:layout_constraintBottom_toTopOf="@id/edit_card"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.chip.ChipGroup
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="16dp"
+            app:singleLine="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/add"
+                style="@style/Widget.Material3.Chip.Assist.Elevated"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/peq_add_band"
+                app:chipIcon="@drawable/ic_baseline_add_24dp" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/reset"
+                style="@style/Widget.Material3.Chip.Assist.Elevated"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/peq_reset"
+                app:chipIcon="@drawable/ic_twotone_delete_forever_24dp" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/import_file"
+                style="@style/Widget.Material3.Chip.Assist.Elevated"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/peq_import"
+                app:chipIcon="@drawable/ic_twotone_download_24" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/export_file"
+                style="@style/Widget.Material3.Chip.Assist.Elevated"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/peq_export"
+                app:chipIcon="@drawable/ic_twotone_save_24dp" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/edit_string"
+                style="@style/Widget.Material3.Chip.Assist.Elevated"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/peq_edit_as_string"
+                app:chipIcon="@drawable/ic_twotone_edit_24dp" />
+        </com.google.android.material.chip.ChipGroup>
+    </HorizontalScrollView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/edit_card"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginHorizontal="16dp"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintVertical_weight="0"
+        app:layout_constraintHeight_default="spread"
+        app:layout_constraintBottom_toTopOf="@id/preview_card"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/horizontalScrollView">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="2dp"
+                android:orientation="horizontal">
+                <TextView
+                    android:id="@+id/edit_card_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:text="@string/peq_band_list"
+                    android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1" />
+
+                <LinearLayout
+                    android:id="@+id/band_detail_context_buttons"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="visible"
+                    android:orientation="horizontal">
+                    <Button
+                        style="?attr/materialIconButtonFilledTonalStyle"
+                        android:id="@+id/cancel"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/peq_cancel_spaced"
+                        android:contentDescription="@string/peq_cancel"
+                        android:tooltipText="@string/peq_cancel"
+                        app:icon="@drawable/ic_close_24dp" />
+
+                    <Button
+                        style="?attr/materialIconButtonFilledStyle"
+                        android:id="@+id/confirm"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/peq_done_spaced"
+                        android:contentDescription="@string/peq_done"
+                        android:tooltipText="@string/peq_done"
+                        app:icon="@drawable/ic_twotone_check_24dp" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <View
+                android:id="@+id/divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?android:attr/listDivider" />
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <LinearLayout
+                    android:id="@+id/empty_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center"
+                    android:visibility="gone"
+                    android:gravity="center">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:gravity="center"
+                        android:alpha="0.8"
+                        android:text="@string/peq_no_bands_defined"
+                        android:textAppearance="?attr/textAppearanceTitleMedium"
+                        app:drawableTint="?attr/colorOnBackground"
+                        app:drawableTopCompat="@drawable/ic_twotone_nodes_24dp" />
+                </LinearLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/band_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:visibility="gone"
+                    android:scrollbars="vertical"/>
+
+                <androidx.core.widget.NestedScrollView
+                    android:id="@+id/band_edit"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    tools:ignore="SpeakableTextPresentCheck">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginHorizontal="16dp"
+                        android:layout_marginTop="16dp"
+                        android:orientation="vertical">
+
+                        <me.timschneeberger.rootlessjamesdsp.view.NumberInputBox
+                            android:id="@+id/freqInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            app:helperText="@string/peq_frequency_range"
+                            app:helperTextEnabled="true"
+                            app:hintText="@string/peq_frequency"
+                            app:step="10"
+                            app:suffixText="Hz"
+                            app:value="1000"
+                            app:floatPrecision="1"
+                            android:min="20"
+                            android:max="20000" />
+
+                        <me.timschneeberger.rootlessjamesdsp.view.NumberInputBox
+                            android:id="@+id/gainInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            app:helperText="@string/peq_gain_range"
+                            app:helperTextEnabled="true"
+                            app:hintText="@string/peq_gain"
+                            app:floatPrecision="2"
+                            app:step="0.5"
+                            app:suffixText="dB"
+                            app:value="0"
+                            android:min="-30"
+                            android:max="30"/>
+
+                        <me.timschneeberger.rootlessjamesdsp.view.NumberInputBox
+                            android:id="@+id/qInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            app:helperText="@string/peq_q_range"
+                            app:helperTextEnabled="true"
+                            app:hintText="@string/peq_q_factor"
+                            app:floatPrecision="2"
+                            app:step="0.1"
+                            app:value="1.41"
+                            android:min="0"
+                            android:max="30" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:layout_marginBottom="4dp"
+                            android:text="@string/peq_filter_type"
+                            android:textAppearance="?attr/textAppearanceLabelLarge" />
+
+                        <com.google.android.material.button.MaterialButtonToggleGroup
+                            android:id="@+id/filter_type_group"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="16dp"
+                            app:singleSelection="true"
+                            app:selectionRequired="true">
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/filter_peaking"
+                                style="?attr/materialButtonOutlinedStyle"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:text="@string/peq_filter_type_peaking" />
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/filter_low_shelf"
+                                style="?attr/materialButtonOutlinedStyle"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:text="@string/peq_filter_type_low_shelf" />
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/filter_high_shelf"
+                                style="?attr/materialButtonOutlinedStyle"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:text="@string/peq_filter_type_high_shelf" />
+                        </com.google.android.material.button.MaterialButtonToggleGroup>
+                    </LinearLayout>
+
+                </androidx.core.widget.NestedScrollView>
+            </FrameLayout>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/preview_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/edit_card">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:animateLayoutChanges="true">
+
+            <TextView
+                android:id="@+id/preview_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@string/peq_preview"
+                android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+            <me.timschneeberger.rootlessjamesdsp.view.NumberInputBox
+                android:id="@+id/preampInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginBottom="8dp"
+                app:helperText="@string/peq_preamp_range"
+                app:helperTextEnabled="true"
+                app:hintText="@string/peq_preamp"
+                app:floatPrecision="1"
+                app:step="0.5"
+                app:suffixText="dB"
+                app:value="0"
+                android:min="-30"
+                android:max="0" />
+
+            <me.timschneeberger.rootlessjamesdsp.view.ParametricEqSurface
+                android:id="@+id/equalizer_surface"
+                android:layout_width="match_parent"
+                android:layout_height="256dp" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_peq_band_list.xml
+++ b/app/src/main/res/layout/item_peq_band_list.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:gravity="center_vertical">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+        <TextView
+            android:id="@+id/filter_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="12dp"
+            android:textAppearance="?attr/textAppearanceLabelMedium"
+            android:textColor="?attr/colorPrimary"/>
+        <TextView
+            android:id="@+id/freq"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="12dp"
+            android:textAppearance="?attr/textAppearanceTitleMedium"/>
+        <TextView
+            android:id="@+id/gain"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="12dp"
+            android:textAppearance="?attr/textAppearanceTitleMedium"/>
+        <TextView
+            android:id="@+id/q_factor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?android:attr/textColorSecondary"/>
+    </LinearLayout>
+
+    <Button
+        style="?attr/materialIconButtonStyle"
+        android:id="@+id/delete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/peq_delete_band"
+        android:tooltipText="@string/peq_delete_band"
+        app:icon="@drawable/ic_twotone_delete_24dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/preference_parametric_equalizer.xml
+++ b/app/src/main/res/layout/preference_parametric_equalizer.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="335dp"
+    android:orientation="vertical">
+
+        <LinearLayout
+            android:minHeight="?android:attr/listPreferredItemHeightSmall"
+            android:gravity="center_vertical"
+            android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+            android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+            android:clipToPadding="false"
+            android:baselineAligned="false"
+            android:orientation="vertical"
+            android:layout_height="79dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:layout_width="match_parent">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:singleLine="true"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                android:text="@string/peq_bands"
+                android:ellipsize="marquee"/>
+            <TextView
+                android:id="@+id/band_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:textAlignment="viewStart"
+                android:textColor="?android:attr/textColorSecondary"
+                android:text="@string/peq_bands"
+                android:maxLines="10"
+                style="@style/PreferenceSummaryTextStyle"/>
+        </LinearLayout>
+
+    <me.timschneeberger.rootlessjamesdsp.view.ParametricEqSurface
+        android:id="@+id/layout_equalizer"
+        android:layout_width="match_parent"
+        android:layout_height="256dp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -103,6 +103,10 @@
     <string name="key_geq_enable" translatable="false">geq_enable</string>
     <string name="key_geq_nodes" translatable="false">geq_nodes</string>
 
+    <string name="key_peq_enable" translatable="false">peq_enable</string>
+    <string name="key_peq_bands" translatable="false">peq_bands</string>
+    <string name="key_peq_preamp" translatable="false">peq_preamp</string>
+
     <string name="key_reverb_enable" translatable="false">reverb_enable</string>
     <string name="key_reverb_preset" translatable="false">reverb_preset</string>
 

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -4,6 +4,10 @@
         <item quantity="one">%d node</item>
         <item quantity="other">%d nodes</item>
     </plurals>
+    <plurals name="peq_bands_count">
+        <item quantity="one">%d band</item>
+        <item quantity="other">%d bands</item>
+    </plurals>
     <plurals name="custom_parameters">
         <item quantity="one">%d customizable parameter</item>
         <item quantity="other">%d customizable parameters</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,45 @@
     <string name="eq_preset_rock">Rock</string>
     <string name="eq_preset_vocal">Vocal Booster</string>
 
+    <string name="peq_enable">Parametric equalizer</string>
+    <string name="peq_bands">Parametric EQ bands</string>
+    <string name="title_activity_peq">Parametric equalizer</string>
+    <string name="peq_add_band">Add</string>
+    <string name="peq_import">Import</string>
+    <string name="peq_export">Export</string>
+    <string name="peq_edit_as_string">Edit as string</string>
+    <string name="peq_reset">Reset</string>
+    <string name="peq_reset_confirm_title">Are you sure?</string>
+    <string name="peq_reset_confirm">Do you want to reset your parametric EQ settings?</string>
+    <string name="peq_band_editor">Band editor</string>
+    <string name="peq_band_list">Band list</string>
+    <string name="peq_no_bands_defined">No bands defined</string>
+    <string name="peq_delete_band">Delete band</string>
+    <string name="peq_done_spaced">&#160;&#160;Done&#160;</string>
+    <string name="peq_done">Done</string>
+    <string name="peq_cancel_spaced">&#160;&#160;Discard&#160;</string>
+    <string name="peq_cancel">Discard</string>
+    <string name="peq_discard_changes_title">Discard changes and exit?</string>
+    <string name="peq_discard_changes">The values are not valid or empty. Your changes can\'t be saved.\nDo you want to discard your changes and exit?</string>
+    <string name="peq_frequency">Frequency</string>
+    <string name="peq_frequency_range">Value between 20Hz and 20000Hz</string>
+    <string name="peq_gain">Gain</string>
+    <string name="peq_gain_range">Value between -30dB and 30dB</string>
+    <string name="peq_q_factor">Q Factor</string>
+    <string name="peq_q_range">Value between 0.1 and 30.0</string>
+    <string name="peq_filter_type">Filter type</string>
+    <string name="peq_filter_type_peaking">Peaking</string>
+    <string name="peq_filter_type_low_shelf">Low shelf</string>
+    <string name="peq_filter_type_high_shelf">High shelf</string>
+    <string name="peq_preview">Preview</string>
+    <string name="peq_preview_collapsed">Preview (tap to expand)</string>
+    <string name="peq_import_success">Successfully imported %d bands</string>
+    <string name="peq_import_error">Failed to import file. Invalid EqualizerAPO format.</string>
+    <string name="peq_export_success">Exported successfully</string>
+    <string name="peq_edit_hint">EqualizerAPO format</string>
+    <string name="peq_preamp">Preamp</string>
+    <string name="peq_preamp_range">Value between -30dB and 0dB</string>
+
     <string name="geq_enable">Arbitrary response equalizer</string>
     <string name="geq_nodes">Magnitude response</string>
 

--- a/app/src/main/res/xml/dsp_parametriceq_preferences.xml
+++ b/app/src/main/res/xml/dsp_parametriceq_preferences.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <me.timschneeberger.rootlessjamesdsp.preference.SwitchPreferenceGroup
+        android:disableDependentsState="false"
+        android:key="@string/key_peq_enable"
+        android:title="@string/peq_enable"
+        android:icon="@drawable/ic_baseline_equalizer_24dp"
+        app:iconSpaceReserved="false">
+        <me.timschneeberger.rootlessjamesdsp.preference.ParametricEqualizerPreference
+            android:key="@string/key_peq_bands"
+            android:defaultValue="PEQ: "
+            android:dialogTitle="@string/peq_bands"
+            android:title="@string/peq_bands"
+            app:iconSpaceReserved="false"/>
+    </me.timschneeberger.rootlessjamesdsp.preference.SwitchPreferenceGroup>
+</PreferenceScreen>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -Djdk.net.unixdomain.tmpdir=C:/tmp
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -Djdk.net.unixdomain.tmpdir=C:/tmp
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -33,7 +33,7 @@ set APP_HOME=%DIRNAME%
 for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m" "-Djdk.net.unixdomain.tmpdir=C:\tmp"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -33,7 +33,7 @@ set APP_HOME=%DIRNAME%
 for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m" "-Djdk.net.unixdomain.tmpdir=C:\tmp"
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome


### PR DESCRIPTION
## Summary
- Added a full parametric equalizer with peaking, low shelf, and high shelf filter types
- Biquad-based filter computation with real-time frequency response preview
- Preamp control (0 to -30 dB) to prevent clipping when boosting
- Import/export support for EqualizerAPO format (including preamp)
- PEQ output merges with the existing graphic EQ via log-linear interpolation